### PR TITLE
Update for "SPARQL-dev" inc links to /w3c/sparql-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SPARQL 1.2 Community Group
+# SPARQL Dev Community Group
 
-Welcome to the [SPARQL 1.2 Community Group](https://www.w3.org/community/sparql-12/) github repository.
+Welcome to the [SPARQL-dev Community Group](https://www.w3.org/community/sparql-dev/) github repository.
 
-[Mailing list archive](https://lists.w3.org/Archives/Public/public-sparql-12/).
+[Mailing list archive](https://lists.w3.org/Archives/Public/public-sparql-dev/).
 
-There are a lot of [issues](https://github.com/w3c/sparql-12/issues) being worked on and also have a look at the [wiki](https://github.com/w3c/sparql-12/wiki)
+There are a lot of [issues](https://github.com/w3c/sparql-dev/issues) being worked on and also have a look at the [wiki](https://github.com/w3c/sparql-dev/wiki)

--- a/SEP/SEP-0002/sep-0002.md
+++ b/SEP/SEP-0002/sep-0002.md
@@ -6,9 +6,9 @@
 
 ## *Notes*
 
-*This might be affected by work on [sparql-12#97](https://github.com/w3c/sparql-12/issues/97) (supporting XPath 3.1).* For the purposes of this SEP, it is assumed that XPath 3.1 is *not* supported, and existing SPARQL semantics continue to be based on [XQuery 1.0 and XPath 2.0 Functions and Operators](https://www.w3.org/TR/xpath-functions/).
+*This might be affected by work on [sparql-dev#97](https://github.com/w3c/sparql-dev/issues/97) (supporting XPath 3.1).* For the purposes of this SEP, it is assumed that XPath 3.1 is *not* supported, and existing SPARQL semantics continue to be based on [XQuery 1.0 and XPath 2.0 Functions and Operators](https://www.w3.org/TR/xpath-functions/).
 
-*Not all of the relevant operators are described below or implemented in the linked tests, but the tests repo does list them in the [README](https://github.com/kasei/sparql-12/blob/xsd_datetime_duration/tests/xsd_functions/README.md).*
+*Not all of the relevant operators are described below or implemented in the linked tests, but the tests repo does list them in the [README](https://github.com/kasei/sparql-dev/blob/xsd_datetime_duration/tests/xsd_functions/README.md).*
 
 ## Abstract
 
@@ -21,7 +21,7 @@ drawn from the [XPath and XQuery Functions and Operators][xpfo]
 
 ## Motivation
 
-As raised in [sparql-12#32](https://github.com/w3c/sparql-12/issues/32), the support in SPARQL 1.1 for `xsd:dateTime` allows only a
+As raised in [sparql-dev#32](https://github.com/w3c/sparql-dev/issues/32), the support in SPARQL 1.1 for `xsd:dateTime` allows only a
 narrow range of queries, and is often insufficient to express queries over
 temporal data. Among other limitations, the supported types, functions, and operators
 available in SPARQL 1.1:
@@ -110,7 +110,7 @@ This proposal is purely additive to SPARQL 1.1.
 
 * [Tests][tests]
 * Implementations:
-    * [Kineo][kineo-sparql-12] (sparql-12 branch)
+    * [Kineo][kineo-sparql-dev] (sparql-dev branch)
     * [Comunica](https://github.com/comunica/comunica) (Excluding the ADJUST function)
 
 [xpfo]: https://www.w3.org/TR/xpath-functions-31/#dateTime-arithmetic
@@ -119,5 +119,5 @@ This proposal is purely additive to SPARQL 1.1.
 [ops]: https://www.w3.org/TR/sparql11-query/#OperatorMapping
 [constr]: https://www.w3.org/TR/sparql11-query/#FunctionMapping
 
-[tests]: https://github.com/kasei/sparql-12/tree/xsd_datetime_duration/tests/xsd_functions
-[kineo-sparql-12]: https://github.com/kasei/kineo/tree/sparql-12
+[tests]: https://github.com/kasei/sparql-dev/tree/xsd_datetime_duration/tests/xsd_functions
+[kineo-sparql-dev]: https://github.com/kasei/kineo/tree/sparql-dev

--- a/SEP/SEP-0003/sep-0003.md
+++ b/SEP/SEP-0003/sep-0003.md
@@ -23,7 +23,7 @@ The functionality of limited connectivity checks is still valid with non-countin
 
 ## Motivation
 
-As raised in [sparql-12#101](https://github.com/w3c/sparql-12/issues/101), it would be nice to have this functionality available in SPARQL 1.2.
+As raised in [sparql-dev#101](https://github.com/w3c/sparql-dev/issues/101), it would be nice to have this functionality available in SPARQL.
 
 Pragmatically many stores already implement the form `{,max}` as the `*` and `+` versions are implicitly limited.
 

--- a/SEP/SEP-0004/sep-0004.md
+++ b/SEP/SEP-0004/sep-0004.md
@@ -8,7 +8,7 @@
 
 In SPARQL 1.1, the unnamed/default graph has no standard name. This means that, when writing code that manipulates graphs, one must special-case the unnamed/default graph. 
 
-Here, we propose the introduction of a URI, as well as a keyword, that can be used to reference the default graph specifically, in both SPARQL 1.2 queries and the SPARQL Protocol. The proposed keyword is `DEFAULT` and the proposed standard URI is 
+Here, we propose the introduction of a URI, as well as a keyword, that can be used to reference the default graph specifically, in both SPARQL queries and the SPARQL Protocol. The proposed keyword is `DEFAULT` and the proposed standard URI is 
 
 (TODO reach consensus on single best URI)
 
@@ -18,7 +18,7 @@ Here, we propose the introduction of a URI, as well as a keyword, that can be us
 
 ## Motivation
 
-As raised in SPARQL 1.2 issue [#43](https://github.com/w3c/sparql-12/issues/43), the core problem is that the default graph cannot be referenced in dataset definitions.
+As raised in SPARQL-dev issue [#43](https://github.com/w3c/sparql-dev/issues/43), the core problem is that the default graph cannot be referenced in dataset definitions.
 
 ## Rationale and Alternatives
 
@@ -37,7 +37,7 @@ This clearly demonstrates a pragmatic need for a way to reference the default gr
 
 ## Evidence of consensus
 
-See discussion on SPARQL 1.2 issue [#43](https://github.com/w3c/sparql-12/issues/43).
+See discussion on SPARQL-dev issue [#43](https://github.com/w3c/sparql-dev/issues/43).
 
 ## Specification:
 

--- a/SEP/SEP-0006/sep-0006.md
+++ b/SEP/SEP-0006/sep-0006.md
@@ -4,7 +4,7 @@
 * SEP Number: [SEP-0006](sep-0006.md)
 * Author: Andy Seaborne
 
-Discussion: SPARQL-12 [Issue #100](https://github.com/w3c/sparql-12/issues/100) (and elsewhere)
+Discussion: SPARQL-dev [Issue #100](https://github.com/w3c/sparql-dev/issues/100) (and elsewhere)
 
 Based on previous work : Oxigraph: [oxigraph/issues/267](https://github.com/oxigraph/oxigraph/issues/267)
 
@@ -98,7 +98,7 @@ There is a similarity to `filter` `NOT EXISTS`/`EXISTS` expressed as the not-leg
 
 ### Elsewhere
 
-* https://github.com/w3c/sparql-12/issues/100
+* https://github.com/w3c/sparql-dev/issues/100
 * Apache Jena's [SERVICE <loop:>](https://jena.apache.org/documentation/query/service_enhancer.html)
 * Oxigraph: [oxigraph/issues/267](https://github.com/oxigraph/oxigraph/issues/267),
   [oxigraph/pull/274](https://github.com/oxigraph/oxigraph/pull/274)

--- a/SEP/SEP-0007/sep-0007.md
+++ b/SEP/SEP-0007/sep-0007.md
@@ -4,7 +4,7 @@
 
 * SEP number: [SEP-0007](sep-0007.md)
 * Discussion: 
-  [SPARQL Errata 8](https://www.w3.org/2013/sparql-errata#errata-query-8), [issue 89](https://github.com/w3c/sparql-12/issues/89#issuecomment-547352909)
+  [SPARQL Errata 8](https://www.w3.org/2013/sparql-errata#errata-query-8), [issue 89](https://github.com/w3c/sparql-dev/issues/89#issuecomment-547352909)
 * Author: Andy Seaborne
 
 ## Abstract

--- a/docs/charter.html
+++ b/docs/charter.html
@@ -4,11 +4,11 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>
-      SPARQL 1.2 Community Group Charter
+      SPARQL-dev Community Group Charter
     </title>
     
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="./sparql-12-charter.css"/>
+    <link rel="stylesheet" href="./sparql-dev-charter.css"/>
     <style>
       body {
         max-width: 60em;
@@ -31,16 +31,16 @@
   </head>
   <body>
     <h1>
-      [DRAFT] SPARQL 1.2 Community Group Charter
+      [DRAFT] SPARQL-dev Community Group Charter
     </h1>
     <p>
       This Charter is a work in progress. 
       To submit feedback, please use 
-      <a href="https://github.com/w3c/sparql-12/issues">GitHub repository Issues</a>
+      <a href="https://github.com/w3c/sparql-dev/issues">GitHub repository Issues</a>
       where the Charter is being developed.
     </p>
     <ul>
-      <li>This Charter: <a href="https://w3c.github.io/sparql-12/charter.html">https://w3c.github.io/sparql-12/charter.html</a>
+      <li>This Charter: <a href="https://w3c.github.io/sparql-dev/charter.html">https://w3c.github.io/sparql-dev/charter.html</a>
       </li>
       <li>Previous Charter: 
       </li>
@@ -53,7 +53,7 @@
       Goals
     </h2>
     <p>
-      The goal of the SPARQL 1.2 Community Group is to advance the functionality of SPARQL
+      The goal of the SPARQL-dev Community Group is to advance the functionality of SPARQL
       by producing a Community Group report describing new features for consideration by a
       future SPARQL Working Group.
     </p>
@@ -84,7 +84,7 @@
       Scope of Work
     </h2>
     <p>
-      The SPARQL 1.2 Community Group is a forum for discussion and refinement of SPARQL
+      The SPARQL-dev Community Group is a forum for discussion and refinement of SPARQL
       1.1. It will document features found as extensions to available triple stores and
       also document common needs from the user community. The Community Group aims to
       create consensus and understanding of the impact of new features with special
@@ -121,7 +121,7 @@
     <p>
       The group may produce test suites to support the features described.
       Please see the 
-      <a href="https://github.com/w3c/sparql-12/blob/master/LICENSE.md">GitHub LICENSE</a> 
+      <a href="https://github.com/w3c/sparql-dev/blob/master/LICENSE.md">GitHub LICENSE</a> 
       file for test suite contribution licensing information.
     </p>
     <h2 id="liaisons">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,18 +1,18 @@
 <html>
   <head>
-    <title>SPARQL 1.2 Community Group</title>
+    <title>SPARQL-dev Community Group</title>
   </head>
 
 <body>
-  <h1>SPARQL 1.2 Community Group</h1>
+  <h1>SPARQL-dev Community Group</h1>
   <p>
-    This is the github pages home for the <a href="https://www.w3.org/community/sparql-12/">SPARQL 1.2 Community Group</a>.
+    This is the github pages home for the <a href="https://www.w3.org/community/sparql-12/">SPARQL-dev Community Group</a>.
   </p>
   <p>
-    <a href="https://github.com/w3c/sparql-12/">Github repository</a>
+    <a href="https://github.com/w3c/sparql-dev/">Github repository</a>
   </p>
   <p>
-    <a href="https://lists.w3.org/Archives/Public/public-sparql-12/">Mailing list archive</a>
+    <a href="https://lists.w3.org/Archives/Public/public-sparql-dev-cg/">Mailing list archive</a>
   </p>
 </body>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: null
-title: SPARQL 1.2 Community Group
+title: SPARQL-dev Community Group
 ---
-This is the github pages home for the "[SPARQL 1.2 Community Group](https://www.w3.org/community/sparql-12/)"
+This is the github pages home for the "[SPARQL-dev Community Group](https://www.w3.org/community/sparql-dev/)"
 
-[Github respository](https://githuib.com/w3c/sparql12/)
+[Github respository](https://githuib.com/w3c/sparql-dev/)


### PR DESCRIPTION
This PR updates site docs and SEPs for the rename to SPARQL-dev and links /w3c/sparql-dev.
