### PR TITLE
sep-0010

### DIFF
--- a/SEP/SEP-0010/sep-0010.md
+++ b/SEP/SEP-0010/sep-0010.md
@@ -1,0 +1,64 @@
+## Unintuitive behavior of NegatedPropertySets with reverse properties
+
+## NegatedPropertySets with reverse iri's
+
+## [SEP-0010](sep-0010.md)
+
+## Authors
+[William Van Woensel](https://github.com/william-vw)
+
+## Abstract
+I recently noticed unintuitive behavior when using reverse properties in NegatedPropertySets. 
+The [translation to the SPARQL algebra](https://www.w3.org/TR/sparql11-query/#sparqlTranslatePathExpressions) means that a single NegatedPropertySet that mixes non-reverse and reverse IRI's essentially issues two separate queries.
+
+This is not necessarily an enhancement proposal, but rather describes this behavior and why I find it unintuitive.
+
+## Motivation
+This query example:
+```
+PREFIX :   <http://example.org/>
+:x0 :p1 :x1 .
+:x0 :p2 :x1 .
+:x2 :p :x3 .
+
+PREFIX :   <http://example.org/>
+SELECT * { ?x0 !( :p1 | :p2 ) ?x1 . }
+```
+
+Results in pairs of terms that are not connected through either `:p1` or `:p2`, namely:  
+`:x2`, `:x3`
+
+For this query example:
+```
+PREFIX :   <http://example.org/>
+:x3 :p1 :x2 .
+:x2 :p :x3 .
+
+PREFIX :   <http://example.org/>
+SELECT * { ?x0 !( :p1 | ^:p1 ) ?x1 . }
+```
+As a result, I would similarly expect pairs of terms that are not connected either through `:p1` or inversely through `:p1`.
+I.e., I wouldn't expect any results here.
+
+Instead, it returns `:x2, :x3` and `:x3, :x2`, which **do not** meet the above description: `:x2, :x3` are inversely connected through `:p1`, and `:x3, :x2` are connected through `:p1`.
+
+It is clear why: due to its [algebra translation](https://www.w3.org/TR/sparql11-query/#sparqlTranslatePathExpressions), this type of expression essentially issues two queries:
+- return all x0's and x1's that are not connected through `:p1` (here, `:x2, :x3`), and 
+- return all x0's and x1's that are not inversely connected through `:p1` (here, `:x3, :x2`).
+
+I am not necessarily advocating to change this behaviour (which may have widespread implications for SPARQL implementations).
+
+But, I am wondering whether others also find this behaviour unintuitive; if so, whether they believe it should be fixed, or a note should be added to the specification.
+
+## Rationale and Alternatives
+Not (yet) applicable here.
+
+## Evidence of consensus
+None yet.
+
+## Specification:
+
+
+## Backwards Compatibility
+
+## Tests and implementations


### PR DESCRIPTION
I recently noticed unintuitive behavior when using reverse properties in NegatedPropertySets. 
The [translation to the SPARQL algebra](https://www.w3.org/TR/sparql11-query/#sparqlTranslatePathExpressions) means that a single NegatedPropertySet that mixes non-reverse and reverse IRI's essentially issues two separate queries.

This is not necessarily an enhancement proposal, but rather describes this behavior and why I find it unintuitive.
